### PR TITLE
Introduced minor tweaks to inline editor content.

### DIFF
--- a/user-interface-inline/index.html
+++ b/user-interface-inline/index.html
@@ -20,8 +20,8 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 	<div class="editor-wrapper">
 		<div id="cke5-user-interface-inline-demo">
 			<header id="inline-header">
-				<h2>Gone traveling</h2>
-				<h3>Monthly travel news and inspiration</h3>
+				<h2 style="text-align:center;">Gone traveling</h2>
+				<h3 style="text-align:center;">Monthly travel news and inspiration</h3>
 			</header>
 
 			<div id="inline-main">
@@ -41,14 +41,14 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 				<div class="demo-row__half">
 					<div id="inline-footer-first">
 						<h3>The three greatest things you learn from traveling</h3>
-						<p><a href="#">Find out more</a></p>
+						<p><a href="https://example.com/" target="_blank" rel="external">Find out more</a></p>
 					</div>
 				</div>
 
 				<div class="demo-row__half">
 					<div id="inline-footer-second">
 						<h3>Walking the capitals of Europe: Warsaw</h3>
-						<p><a href="#">Find out more</a></p>
+						<p><a href="https://example.com/" target="_blank" rel="external">Find out more</a></p>
 					</div>
 				</div>
 			</div>

--- a/user-interface-inline/index.js
+++ b/user-interface-inline/index.js
@@ -6,6 +6,7 @@
 import InlineEditor from '@ckeditor/ckeditor5-editor-inline/src/inlineeditor';
 
 import UploadAdapter from '@ckeditor/ckeditor5-adapter-ckfinder/src/uploadadapter';
+import Alignment from '@ckeditor/ckeditor5-alignment/src/alignment';
 import Autoformat from '@ckeditor/ckeditor5-autoformat/src/autoformat';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
@@ -34,6 +35,7 @@ const defaultConfig = {
 	plugins: [
 		Essentials,
 		UploadAdapter,
+		Alignment,
 		Autoformat,
 		Bold,
 		Italic,
@@ -102,6 +104,7 @@ const defaultConfig = {
 const headerConfig = {
 	plugins: [
 		Essentials,
+		Alignment,
 		Autoformat,
 		Bold,
 		Italic,
@@ -114,7 +117,9 @@ const headerConfig = {
 		'|',
 		'bold',
 		'italic',
-		'link'
+		'link',
+		'|',
+		'alignment'
 	],
 	heading: {
 		options: [
@@ -128,6 +133,9 @@ const headerConfig = {
 	link: {
 		addTargetToExternalLinks: true,
 		defaultProtocol: 'https://'
+	},
+	alignment: {
+		options: [ 'left', 'center', 'right' ]
 	}
 };
 

--- a/user-interface-inline/package.json
+++ b/user-interface-inline/package.json
@@ -8,6 +8,7 @@
 	"private": true,
 	"devDependencies": {
 		"@ckeditor/ckeditor5-adapter-ckfinder": "^35.4.0",
+		"@ckeditor/ckeditor5-alignment": "^35.4.0",
 		"@ckeditor/ckeditor5-autoformat": "^35.4.0",
 		"@ckeditor/ckeditor5-basic-styles": "^35.4.0",
 		"@ckeditor/ckeditor5-block-quote": "^35.4.0",


### PR DESCRIPTION
## Suggested merge commit message
Introduced minor tweaks to inline editor content. Part of [#2571](https://github.com/cksource/ckeditor5-internal/issues/2571).

---

## Additional information
I've made the following changes to the line editor content:
1. Replaced `#` with `https://example.com` in the footer editor links.
2. Centered the content of the header editor (this required adding the alignment plugin).

I'm introducing the same changes to the docs as part of [#2559](https://github.com/cksource/ckeditor5-internal/issues/2559).