### PR TITLE
Update 3rd-party plugins to NIM compatible versions

### DIFF
--- a/ai-assistant/index.js
+++ b/ai-assistant/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 
@@ -22,7 +22,7 @@ const AI_API_URL = '';
 if (!AI_API_URL) {
 	alert(
 		'CKEditor AI Assistant included in this demo requires additional configuration.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/feature-rich/index.js
+++ b/feature-rich/index.js
@@ -96,7 +96,7 @@ import {
 	Template,
 } from 'ckeditor5-premium-features';
 
-// import WProofreader from '@webspellchecker/wproofreader-ckeditor5/src/wproofreader';
+import { WProofreader } from '@webspellchecker/wproofreader-ckeditor5';
 
 import 'ckeditor5/ckeditor5.css';
 import 'ckeditor5-premium-features/ckeditor5-premium-features.css';
@@ -569,8 +569,7 @@ ClassicEditor.create(
 			TodoList,
 			Underline,
 			WordCount,
-			// @TODO WProofreader needs to be migrated to NIM compatible package first to work here.
-			// ...(WEB_SPELL_CHECKER_LICENSE_KEY ? [WProofreader] : []),
+			...(WEB_SPELL_CHECKER_LICENSE_KEY ? [WProofreader] : []),
 			...(LICENSE_KEY ? [
 				CaseChange,
 				ExportPdf,

--- a/feature-rich/index.js
+++ b/feature-rich/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/feature-rich/package.json
+++ b/feature-rich/package.json
@@ -17,6 +17,7 @@
 	"devDependencies": {
 		"ckeditor5": "^42.0.0",
 		"ckeditor5-premium-features": "^42.0.0",
+		"@webspellchecker/wproofreader-ckeditor5": "^3.0.0",
 		"vite": "^5.0.0"
 	}
 }

--- a/markdown/index.js
+++ b/markdown/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/mathtype/index.js
+++ b/mathtype/index.js
@@ -32,7 +32,7 @@ import {
 	Underline,
 } from 'ckeditor5';
 
-// import MathType from '@wiris/mathtype-ckeditor5/src/plugin';
+import MathType from '@wiris/mathtype-ckeditor5/dist/index.js';
 
 import 'ckeditor5/ckeditor5.css';
 
@@ -41,8 +41,7 @@ ClassicEditor.create(
 	{
 		plugins: [
 			CloudServices,
-			// @TODO MathType needs to be migrated to NIM compatible package first to work here.
-			// MathType,
+			MathType,
 			Essentials,
 			Alignment,
 			Autoformat,

--- a/mathtype/package.json
+++ b/mathtype/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"ckeditor5": "^42.0.0",
-		"@wiris/mathtype-ckeditor5": "8.7.1",
+		"@wiris/mathtype-ckeditor5": "^8.10.0",
 		"vite": "^5.0.0"
 	}
 }

--- a/paste-from-office-enhanced/index.js
+++ b/paste-from-office-enhanced/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/productivity-pack/index.js
+++ b/productivity-pack/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/productivity-pack/index.js
+++ b/productivity-pack/index.js
@@ -81,7 +81,7 @@ import {
 	SlashCommand,
 } from 'ckeditor5-premium-features';
 
-// import WProofreader from '@webspellchecker/wproofreader-ckeditor5/src/wproofreader';
+import { WProofreader } from '@webspellchecker/wproofreader-ckeditor5';
 
 import 'ckeditor5/ckeditor5.css';
 import 'ckeditor5-premium-features/ckeditor5-premium-features.css';
@@ -528,8 +528,7 @@ DecoupledEditor.create(
 			TableToolbar,
 			TextTransformation,
 			Underline,
-			// @TODO WProofreader needs to be migrated to NIM compatible package first to work here.
-			// ...(WEB_SPELL_CHECKER_LICENSE_KEY ? [WProofreader] : []),
+			...(WEB_SPELL_CHECKER_LICENSE_KEY ? [WProofreader] : []),
 			...(LICENSE_KEY ? [
 				ExportPdf,
 				ExportWord,

--- a/productivity-pack/package.json
+++ b/productivity-pack/package.json
@@ -17,6 +17,7 @@
 	"devDependencies": {
 		"ckeditor5": "^42.0.0",
 		"ckeditor5-premium-features": "^42.0.0",
+		"@webspellchecker/wproofreader-ckeditor5": "^3.0.0",
 		"vite": "^5.0.0"
 	}
 }

--- a/source-code-editing/index.js
+++ b/source-code-editing/index.js
@@ -91,7 +91,7 @@ import {
 	SlashCommand,
 } from 'ckeditor5-premium-features';
 
-// import WProofreader from '@webspellchecker/wproofreader-ckeditor5/src/wproofreader';
+import { WProofreader } from '@webspellchecker/wproofreader-ckeditor5';
 
 import 'ckeditor5/ckeditor5.css';
 import 'ckeditor5-premium-features/ckeditor5-premium-features.css';
@@ -575,8 +575,7 @@ ClassicEditor.create(
 			TextTransformation,
 			TodoList,
 			Underline,
-			// @TODO WProofreader needs to be migrated to NIM compatible package first to work here.
-			// ...(WEB_SPELL_CHECKER_LICENSE_KEY ? [WProofreader] : []),
+			...(WEB_SPELL_CHECKER_LICENSE_KEY ? [WProofreader] : []),
 			...(LICENSE_KEY ? [
 				ExportPdf,
 				ExportWord,

--- a/source-code-editing/index.js
+++ b/source-code-editing/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/source-code-editing/package.json
+++ b/source-code-editing/package.json
@@ -17,6 +17,7 @@
 	"devDependencies": {
 		"ckeditor5": "^42.0.0",
 		"ckeditor5-premium-features": "^42.0.0",
+		"@webspellchecker/wproofreader-ckeditor5": "^3.0.0",
 		"vite": "^5.0.0"
 	}
 }

--- a/user-interface-balloon-block/index.js
+++ b/user-interface-balloon-block/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/user-interface-balloon/index.js
+++ b/user-interface-balloon/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/user-interface-bottom-toolbar/index.js
+++ b/user-interface-bottom-toolbar/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/user-interface-button-grouping/index.js
+++ b/user-interface-button-grouping/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/user-interface-classic/index.js
+++ b/user-interface-classic/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/user-interface-document/index.js
+++ b/user-interface-document/index.js
@@ -90,10 +90,12 @@ import {
 	CaseChange,
 } from 'ckeditor5-premium-features';
 
-// import WProofreader from '@webspellchecker/wproofreader-ckeditor5/src/wproofreader';
+import { WProofreader } from '@webspellchecker/wproofreader-ckeditor5';
 
 import 'ckeditor5/ckeditor5.css';
 import 'ckeditor5-premium-features/ckeditor5-premium-features.css';
+
+import '@webspellchecker/wproofreader-ckeditor5/index.css';
 
 import coreStylesheets from 'ckeditor5/ckeditor5.css?url';
 import premiumStylesheets from 'ckeditor5-premium-features/ckeditor5-premium-features.css?url';
@@ -668,8 +670,7 @@ DecoupledEditor.create(
 			TableToolbar,
 			TextTransformation,
 			Underline,
-			// @TODO WProofreader needs to be migrated to NIM compatible package first to work here.
-			// ...(WEB_SPELL_CHECKER_LICENSE_KEY ? [WProofreader] : []),
+			...(WEB_SPELL_CHECKER_LICENSE_KEY ? [WProofreader] : []),
 			...(LICENSE_KEY ? [
 				CaseChange,
 				DocumentOutline,

--- a/user-interface-document/index.js
+++ b/user-interface-document/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/user-interface-document/package.json
+++ b/user-interface-document/package.json
@@ -17,6 +17,7 @@
 	"devDependencies": {
 		"ckeditor5": "^42.0.0",
 		"ckeditor5-premium-features": "^42.0.0",
+		"@webspellchecker/wproofreader-ckeditor5": "^3.0.0",
 		"vite": "^5.0.0"
 	}
 }

--- a/user-interface-inline/index.js
+++ b/user-interface-inline/index.js
@@ -11,7 +11,7 @@ const LICENSE_KEY = '';
 if (!LICENSE_KEY) {
 	alert(
 		'CKEditor Commercial Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/wproofreader/index.js
+++ b/wproofreader/index.js
@@ -39,11 +39,11 @@ import {
 	TodoList,
 } from 'ckeditor5';
 
-// import { WProofreader } from '@webspellchecker/wproofreader-ckeditor5';
+import { WProofreader } from '@webspellchecker/wproofreader-ckeditor5';
 
 import 'ckeditor5/ckeditor5.css';
 
-// import '@webspellchecker/wproofreader-ckeditor5/index.css';
+import '@webspellchecker/wproofreader-ckeditor5/index.css';
 
 ClassicEditor.create(
 	document.querySelector('#cke5-spellchecker-demo'),
@@ -70,8 +70,7 @@ ClassicEditor.create(
 			TableToolbar,
 			TextTransformation,
 			TodoList,
-			// @TODO WProofreader needs to be migrated to NIM compatible package first to work here.
-			// WProofreader,
+			WProofreader,
 		],
 		toolbar: {
 			items: [

--- a/wproofreader/index.js
+++ b/wproofreader/index.js
@@ -10,7 +10,7 @@ const WEB_SPELL_CHECKER_LICENSE_KEY = '';
 if (!WEB_SPELL_CHECKER_LICENSE_KEY) {
 	alert(
 		'Web Spell Checker Features included in this demo require a license key.\n' +
-		'Check the index.ts file for more information.'
+		'Check the index.js file for more information.'
 	);
 }
 

--- a/wproofreader/package.json
+++ b/wproofreader/package.json
@@ -16,6 +16,7 @@
 	},
 	"devDependencies": {
 		"ckeditor5": "^42.0.0",
+		"@webspellchecker/wproofreader-ckeditor5": "^3.0.0",
 		"vite": "^5.0.0"
 	}
 }


### PR DESCRIPTION
This PR updates MathType and WProofreader to latest versions (NIM compatible).

I also fixed license key message as it mentioned `index.ts` instead of `index.js`.

Fixes #41.