### PR TITLE
Integrate Sentry error monitoring in the AI demos

### DIFF
--- a/ai-assistant/index.html
+++ b/ai-assistant/index.html
@@ -6,6 +6,12 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="stylesheet" href="demo.css" />
 		<link rel="stylesheet" href="content.css" />
+
+		<!-- Sentry error monitoring, loaded via the Sentry Loader Script for the "ckeditor-5-ai" project (same approach as the docs site). -->
+		<script
+			src="https://js-de.sentry-cdn.com/b0a9baa1e574d3f3e1b544899bf3f1b0.min.js"
+			crossorigin="anonymous"
+		></script>
 	</head>
 
 	<body>

--- a/ai-assistant/index.js
+++ b/ai-assistant/index.js
@@ -388,5 +388,6 @@ ClassicEditor.create(
 		window.editor = editor;
 	} )
 	.catch( error => {
+		window.Sentry?.captureException( error );
 		console.error( error.stack );
 	} );

--- a/ai-features-spotlight/index.html
+++ b/ai-features-spotlight/index.html
@@ -6,6 +6,12 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="stylesheet" href="demo.css" />
 		<link rel="stylesheet" href="content.css" />
+
+		<!-- Sentry error monitoring, loaded via the Sentry Loader Script for the "ckeditor-5-ai" project (same approach as the docs site). -->
+		<script
+			src="https://js-de.sentry-cdn.com/b0a9baa1e574d3f3e1b544899bf3f1b0.min.js"
+			crossorigin="anonymous"
+		></script>
 	</head>
 	<body>
 		<header class="header-wrapper demo-page-header">

--- a/ai-features-spotlight/index.js
+++ b/ai-features-spotlight/index.js
@@ -2537,7 +2537,10 @@ function initAiClassicEditor() {
 			showEditorWrapper( { editorWrapperClass: '.js-editor-wrapper-ai-classic', classToRemove: 'u-gone' } );
 			startViewportTopOffsetUpdater( editor );
 		} )
-		.catch( error => console.error( error.stack ) );
+		.catch( error => {
+			window.Sentry?.captureException( error );
+			console.error( error.stack );
+		} );
 }
 
 function initAiChatEditor() {
@@ -2582,7 +2585,10 @@ function initAiChatEditor() {
 			showEditorWrapper( { editorWrapperClass: '.js-editor-wrapper-ai-chat', classToRemove: 'u-gone' } );
 			startViewportTopOffsetUpdater( editor );
 		} )
-		.catch( error => console.error( error.stack ) );
+		.catch( error => {
+			window.Sentry?.captureException( error );
+			console.error( error.stack );
+		} );
 }
 
 function initAiQuickActionsEditor() {
@@ -2617,7 +2623,10 @@ function initAiQuickActionsEditor() {
 			showEditorWrapper( { editorWrapperClass: '.js-editor-wrapper-ai-quick-actions', classToRemove: 'u-gone' } );
 			startViewportTopOffsetUpdater( editor );
 		} )
-		.catch( error => console.error( error.stack ) );
+		.catch( error => {
+			window.Sentry?.captureException( error );
+			console.error( error.stack );
+		} );
 }
 
 function initAiReviewEditor() {
@@ -2665,7 +2674,10 @@ function initAiReviewEditor() {
 			showEditorWrapper( { editorWrapperClass: '.js-editor-wrapper-ai-review', classToRemove: 'u-gone' } );
 			startViewportTopOffsetUpdater( editor );
 		} )
-		.catch( error => console.error( error.stack ) );
+		.catch( error => {
+			window.Sentry?.captureException( error );
+			console.error( error.stack );
+		} );
 }
 
 function initAiTranslateEditor() {
@@ -2713,7 +2725,10 @@ function initAiTranslateEditor() {
 			showEditorWrapper( { editorWrapperClass: '.js-editor-wrapper-ai-translate', classToRemove: 'u-gone' } );
 			startViewportTopOffsetUpdater( editor );
 		} )
-		.catch( error => console.error( error.stack ) );
+		.catch( error => {
+			window.Sentry?.captureException( error );
+			console.error( error.stack );
+		} );
 }
 
 const MCP_STATUS_MESSAGES = {
@@ -2834,7 +2849,10 @@ function initAiMcpEditor() {
 			showEditorWrapper( { editorWrapperClass: '.js-editor-wrapper-ai-mcp', classToRemove: 'u-gone' } );
 			startViewportTopOffsetUpdater( editor );
 		} )
-		.catch( error => console.error( error.stack ) );
+		.catch( error => {
+			window.Sentry?.captureException( error );
+			console.error( error.stack );
+		} );
 }
 
 function initAiBalloonEditor() {
@@ -2968,7 +2986,10 @@ function initAiBalloonEditor() {
 			showEditorWrapper( { editorWrapperClass: '.js-editor-wrapper-ai-balloon', classToRemove: 'u-gone' } );
 			startViewportTopOffsetUpdater( editor );
 		} )
-		.catch( error => console.error( error.stack ) );
+		.catch( error => {
+			window.Sentry?.captureException( error );
+			console.error( error.stack );
+		} );
 }
 
 // Builds the custom AI tab UI: panels wrapper (top) → buttons bar → disclaimer (bottom).

--- a/ai/index.html
+++ b/ai/index.html
@@ -6,6 +6,12 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="stylesheet" href="demo.css" />
 		<link rel="stylesheet" href="content.css" />
+
+		<!-- Sentry error monitoring, loaded via the Sentry Loader Script for the "ckeditor-5-ai" project (same approach as the docs site). -->
+		<script
+			src="https://js-de.sentry-cdn.com/b0a9baa1e574d3f3e1b544899bf3f1b0.min.js"
+			crossorigin="anonymous"
+		></script>
 	</head>
 
 	<body>

--- a/ai/index.js
+++ b/ai/index.js
@@ -772,6 +772,7 @@ Tone: [e.g. Clear, practical, collaborative]`,
 		return editor;
 	} )
 	.catch( err => {
+		window.Sentry?.captureException( err );
 		console.error( err );
 	} );
 


### PR DESCRIPTION
## Suggested merge commit message

Integrate Sentry error monitoring in the AI demos (#10246)

## Description

Introduces centralized error reporting for the AI demos, mirroring the setup already used on the documentation site. This gives visibility into errors that occur in the live demos at `ckeditor.com/ckeditor-5/demo`, which previously had no error monitoring (errors were only logged to the browser console).

Scope is limited to the three AI demos:

- `ai`
- `ai-assistant`
- `ai-features-spotlight`

## Changes

- **Sentry Loader Script** added to each demo's `<head>`, pointing at the `ckeditor-5-ai` Sentry project. Same approach as the docs site — no `@sentry/*` SDK dependency, configuration (sample rates, environment, inbound filters) is managed in the Sentry project UI. The script is loaded with `crossorigin="anonymous"` so editor stack traces are not collapsed into opaque `Script error.` entries.
- **Explicit error capture** of editor-bootstrap failures: the existing `.catch()` handlers now call `window.Sentry?.captureException()` alongside the console log. The optional-chaining guard keeps the demos working if the loader is blocked or unavailable.

## Testing

Verified locally end-to-end:

- The loader is served in the page and the CDN responds (HTTP 200, correct CORS headers).
- A genuine bootstrap failure (`token-not-in-jwt-format`) was captured and arrived in the `ckeditor-5-ai` Sentry project, confirming the `captureException` path works.

## Notes

- The key in the `<script src>` is the public DSN key (write-only ingest), so it is safe to commit — consistent with how the loader works on docs.
- Expect a baseline of environmental noise from shared trial/cloud tokens (`token-not-in-jwt-format`, `token-cannot-download-new-token`, `license-key-expired`, `Network Error`). These are best suppressed via inbound filters in the Sentry project rather than in code.
- The Loader's default integrations capture uncaught errors and unhandled rejections; the `captureException` calls extend coverage to the caught bootstrap failures, which are the most relevant demo errors.
