### PR TITLE
CC/20204 - Bump CKBox to `2.13.0`.

### DIFF
--- a/ai-assistant/index.html
+++ b/ai-assistant/index.html
@@ -145,7 +145,7 @@
 			</div>
 		</div>
 
-		<script src="https://cdn.ckbox.io/ckbox/2.12.0/ckbox.js"></script>
+		<script src="https://cdn.ckbox.io/ckbox/2.13.0/ckbox.js"></script>
 		<script type="module" src="index.js"></script>
 	</body>
 </html>

--- a/ai-features-spotlight/index.html
+++ b/ai-features-spotlight/index.html
@@ -652,7 +652,7 @@
 		</div>
 		</div>
 
-		<script src="https://cdn.ckbox.io/ckbox/2.12.0/ckbox.js"></script>
+		<script src="https://cdn.ckbox.io/ckbox/2.13.0/ckbox.js"></script>
 		<script type="module" src="index.js"></script>
 	</body>
 </html>

--- a/ai/index.html
+++ b/ai/index.html
@@ -159,7 +159,7 @@
 			</div>
 		</div>
 
-		<script src="https://cdn.ckbox.io/ckbox/2.12.0/ckbox.js"></script>
+		<script src="https://cdn.ckbox.io/ckbox/2.13.0/ckbox.js"></script>
 		<script type="module" src="index.js"></script>
 	</body>
 </html>

--- a/email-editing/index.html
+++ b/email-editing/index.html
@@ -220,7 +220,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 		</div>
 	</div>
 
-	<script src="https://cdn.ckbox.io/ckbox/2.12.0/ckbox.js"></script>
+	<script src="https://cdn.ckbox.io/ckbox/2.13.0/ckbox.js"></script>
 	<script type="module" src="index.js"></script>
 </body>
 

--- a/feature-rich/index.html
+++ b/feature-rich/index.html
@@ -255,7 +255,7 @@
 			</div>
 		</div>
 
-		<script src="https://cdn.ckbox.io/ckbox/2.12.0/ckbox.js"></script>
+		<script src="https://cdn.ckbox.io/ckbox/2.13.0/ckbox.js"></script>
 		<script type="module" src="index.js"></script>
 	</body>
 </html>

--- a/merge-fields/index.html
+++ b/merge-fields/index.html
@@ -49,7 +49,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 		</div>
 	</div>
 
-	<script src="https://cdn.ckbox.io/ckbox/2.12.0/ckbox.js"></script>
+	<script src="https://cdn.ckbox.io/ckbox/2.13.0/ckbox.js"></script>
 	<script type="module" src="index.js"></script>
 </body>
 

--- a/productivity/index.html
+++ b/productivity/index.html
@@ -176,7 +176,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 			</div>
 		</div>
 
-		<script src="https://cdn.ckbox.io/ckbox/2.12.0/ckbox.js"></script>
+		<script src="https://cdn.ckbox.io/ckbox/2.13.0/ckbox.js"></script>
 		<script type="module" src="./index.js"></script>
 	</body>
 </html>

--- a/source-code-editing/index.html
+++ b/source-code-editing/index.html
@@ -98,7 +98,7 @@
 			</div>
 		</div>
 
-		<script src="https://cdn.ckbox.io/ckbox/2.12.0/ckbox.js"></script>
+		<script src="https://cdn.ckbox.io/ckbox/2.13.0/ckbox.js"></script>
 		<script type="module" src="index.js"></script>
 	</body>
 </html>

--- a/user-interface-classic-with-menu-bar/index.html
+++ b/user-interface-classic-with-menu-bar/index.html
@@ -98,7 +98,7 @@
 			</div>
 		</div>
 
-		<script src="https://cdn.ckbox.io/ckbox/2.12.0/ckbox.js"></script>
+		<script src="https://cdn.ckbox.io/ckbox/2.13.0/ckbox.js"></script>
 		<script type="module" src="index.js"></script>
 	</body>
 </html>

--- a/user-interface-classic/index.html
+++ b/user-interface-classic/index.html
@@ -98,7 +98,7 @@
 			</div>
 		</div>
 
-		<script src="https://cdn.ckbox.io/ckbox/2.12.0/ckbox.js"></script>
+		<script src="https://cdn.ckbox.io/ckbox/2.13.0/ckbox.js"></script>
 		<script type="module" src="index.js"></script>
 	</body>
 </html>

--- a/user-interface-document/index.html
+++ b/user-interface-document/index.html
@@ -133,7 +133,7 @@
 			</div>
 		</div>
 
-		<script src="https://cdn.ckbox.io/ckbox/2.12.0/ckbox.js"></script>
+		<script src="https://cdn.ckbox.io/ckbox/2.13.0/ckbox.js"></script>
 		<script type="module" src="index.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Caused by https://github.com/ckeditor/ckeditor5/issues/20204